### PR TITLE
Mitigate inconsistent behaviour on slow systems

### DIFF
--- a/src/restoreTerminals.ts
+++ b/src/restoreTerminals.ts
@@ -80,17 +80,19 @@ async function runCommands(commands: string[], terminal: vscode.Terminal) {
 
 async function createNewSplitTerminal(name: string | undefined): Promise<vscode.Terminal> {
   return new Promise(async (resolve, reject) => {
-    await vscode.commands.executeCommand("workbench.action.terminal.split");
-    if (name) {
-      await vscode.commands.executeCommand("workbench.action.terminal.renameWithArg", {
-        name
-      })
-    }
-
-    vscode.window.onDidChangeActiveTerminal((terminal) => {
-      if (terminal) {
-        resolve(terminal);
+    const iniCount = vscode.window.terminals.length;
+    yield vscode.commands.executeCommand("workbench.action.terminal.split");
+    yield utilts_1.delay(500);
+    const creCount = vscode.window.terminals.length;
+    if (creCount > iniCount) {
+      if (name) {
+        yield vscode.commands.executeCommand("workbench.action.terminal.renameWithArg", {
+          name
+        });
       }
-    });
-  });
+      yield utilts_1.delay(1000);
+      resolve(vscode.window.terminals[creCount - 1]);
+    } else {
+      resolve(null);
+    }
 }


### PR DESCRIPTION
The onDidChangeActiveTerminal event does not appear to play well with the timing of creating new terminals. This alternative implementation removes the event dependency, and rather utilises simple logic and the known state of window.terminals[]. Also added delays to allow proper finalisation of terminal command execution - without these, it executes before the terminals are in an acceptable ready state. These can be parametrised. Before the change, it failed to restore terminals in about 4/5 attempts. After the change, it succeeds every time. It also mitigates accidentally running commands in the wrong split terminal by clicking on a different during the restore process.