### PR TITLE
Add `cwd` terminal configuration option

### DIFF
--- a/.vscode/SAMPLE_restore-terminals.json
+++ b/.vscode/SAMPLE_restore-terminals.json
@@ -7,11 +7,13 @@
       "splitTerminals": [
         {
           "name": "server",
-          "commands": ["npm i", "npm run dev"]
+          "commands": ["npm i", "npm run dev"],
+          "cwd": "/home/user/server"
         },
         {
           "name": "client",
-          "commands": ["npm run dev:client"]
+          "commands": ["npm run dev:client"],
+          "cwd": "/home/user/client"
         },
         {
           "name": "test",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restore-terminals",
-  "version": "1.1.2",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,6 +2,7 @@ export interface TerminalConfig {
   commands?: string[];
   name?: string;
   shouldRunCommands?: boolean; //whether to actually run the commands, or just paste them in
+  cwd?: string;
 }
 
 export interface TerminalWindow {


### PR DESCRIPTION
This fixes #4, as it allows users to specify the folder that they want each terminal to start in (`cwd`) and it will override `terminal.integrated.splitCwd` temporarily when creating splits so that the user isn't prompted which stops terminals from being created.