### PR TITLE
feat: allow setting terminal color

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ Automatically spawn integrated terminal windows and split terminals, and run any
 
 Simply configure your VSCode settings JSON file to look something like this:
 
-```
+```json
  "restoreTerminals.terminals": [
     {
       "splitTerminals": [
         {
           "name": "server",
-          "commands": ["npm i", "npm run dev"]
+          "commands": ["npm i", "npm run dev"],
+          "color": "terminal.ansiRed"
         },
         {
           "name": "client",
@@ -60,6 +61,8 @@ If you do not want it to restore terminals on VSCode startup, but instead only r
 If you don't want the commands to actually run, just be pasted in the terminal, then set `shouldRunCommands` to `false` in each `splitTerminals` object.
 
 If you don't like using split terminals, then just provide one object in each split terminal array, which should be the intuitive thing to do.
+
+Color is not currently supported for split terminals. Only the first terminal will have the color.
 
 Contributions to the [code](https://github.com/EthanSK/restore-terminals-vscode) are very welcome and much appreciated!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "restore-terminals",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "restore-terminals",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "dependencies": {
         "text-encoding": "^0.7.0"
       },
@@ -15,7 +15,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "^13.11.0",
         "@types/text-encoding": "^0.0.35",
-        "@types/vscode": "^1.46.0",
+        "@types/vscode": "^1.67.0",
         "@typescript-eslint/eslint-plugin": "^2.30.0",
         "@typescript-eslint/parser": "^2.30.0",
         "eslint": "^7.22.0",
@@ -148,9 +148,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.46.0.tgz",
-      "integrity": "sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
+      "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2666,9 +2666,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.46.0.tgz",
-      "integrity": "sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==",
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
+      "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.11.0",
     "@types/text-encoding": "^0.0.35",
-    "@types/vscode": "^1.46.0",
+    "@types/vscode": "^1.67.0",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
     "eslint": "^7.22.0",

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,18 @@
+export enum TerminalColor {
+  "terminal.ansiBlack",
+  "terminal.ansiRed",
+  "terminal.ansiGreen",
+  "terminal.ansiYellow",
+  "terminal.ansiBlue",
+  "terminal.ansiMagenta",
+  "terminal.ansiCyan",
+  "terminal.ansiWhite",
+}
+
 export interface TerminalConfig {
   commands?: string[];
   name?: string;
+  color?: keyof typeof TerminalColor;
   shouldRunCommands?: boolean; //whether to actually run the commands, or just paste them in
 }
 

--- a/src/restoreTerminals.ts
+++ b/src/restoreTerminals.ts
@@ -63,8 +63,11 @@ export default async function restoreTerminals(configuration: Configuration) {
         );
       }
     } else {
+      const color = terminalWindow.splitTerminals[0]?.color;
+
       term = vscode.window.createTerminal({
         name: name,
+        color: new vscode.ThemeColor(color ?? "terminal.ansiWhite"),
         //  cwd: vscode.window.activeTextEditor?.document.uri.fsPath, //i think this happens by default
       });
       term.show();


### PR DESCRIPTION
Addresses https://github.com/EthanSK/restore-terminals-vscode/issues/10#issuecomment-870834680.

Note that color is not supported for split terminals (other than the first) as there's no `changeColor` API that accepts args similar to `renameWithArg`