### PR TITLE
Fix split terminal issue - profile is now configurable on each split terminal instead of root

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -2,6 +2,7 @@ import type { TerminalOptions } from "vscode";
 
 export interface TerminalConfig {
   commands?: string[];
+  profile?: string;
   name?: string;
   icon?: string;
   color?: string;

--- a/src/restoreTerminals.ts
+++ b/src/restoreTerminals.ts
@@ -89,7 +89,8 @@ export default async function restoreTerminals(configuration: Configuration) {
       const splitTerminal = terminalWindow.splitTerminals[i];
       const createdSplitTerm = await createNewSplitTerminal(
         splitTerminal.name,
-        splitTerminal.icon
+        splitTerminal.icon,
+        splitTerminal.profile
       );
       const { commands, shouldRunCommands } = splitTerminal;
       commands &&
@@ -119,12 +120,20 @@ async function runCommands(
 }
 
 async function createNewSplitTerminal(
+  profile: string | undefined,
   name: string | undefined,
-  icon: string | undefined
+  icon: string | undefined,
 ): Promise<vscode.Terminal> {
   return new Promise(async (resolve, reject) => {
     const numTermsBefore = vscode.window.terminals.length;
     await vscode.commands.executeCommand("workbench.action.terminal.split");
+    if (profile) {
+      await vscode.commands.executeCommand(
+        "workbench.action.terminal.newWithProfile",
+        {
+          profile,
+        });
+    }
     if (name) {
       await vscode.commands.executeCommand(
         "workbench.action.terminal.renameWithArg",


### PR DESCRIPTION
This could be a fix the for the problem #26 as I've encountered it too.
I wanted a WSL and a GIT terminal split but you cannot specify the profile for each split terminal, with this commit you should be able to(?)
I'm not sure since I haven't really tested it but I still wrote some fast code to get the idea out of my mind :D