### PR TITLE
Added support for different types of terminal groups

### DIFF
--- a/sample-test-project/.vscode/restore-terminals.json
+++ b/sample-test-project/.vscode/restore-terminals.json
@@ -1,40 +1,51 @@
 {
-  "artificialDelayMilliseconds": 700,
-  "keepExistingTerminalsOpen": false,
-  "runOnStartup": true,
-  "terminals": [
-    {
-      "splitTerminals": [
+    "artificialDelayMilliseconds": 700,
+    "keepExistingTerminalsOpen": false,
+    "runOnStartup": true,
+    "terminals": [
         {
-          "name": "server",
-          "commands": ["npm i", "npm run dev"]
+            "name": "test",
+            "splitTerminals": [
+                {
+                    "name": "server",
+                    "commands": [
+                        "npm i",
+                        "npm run dev"
+                    ]
+                },
+                {
+                    "name": "client",
+                    "commands": [
+                        "npm run dev:client"
+                    ]
+                },
+                {
+                    "name": "test",
+                    "commands": [
+                        "jest --watch"
+                    ]
+                }
+            ]
         },
         {
-          "name": "client",
-          "commands": ["npm run dev:client"]
-        },
-        {
-          "name": "test",
-          "commands": ["jest --watch"]
+            "name": "test2",
+            "splitTerminals": [
+                {
+                    "name": "build & e2e",
+                    "commands": [
+                        "eslint --ext .tsx --ext .ts lib/",
+                        "npm run build",
+                        "npm run e2e"
+                    ],
+                    "shouldRunCommands": false
+                },
+                {
+                    "name": "worker",
+                    "commands": [
+                        "npm-run-all --parallel redis tsc-watch-start worker"
+                    ]
+                }
+            ]
         }
-      ]
-    },
-    {
-      "splitTerminals": [
-        {
-          "name": "build & e2e",
-          "commands": [
-            "eslint --ext .tsx --ext .ts lib/",
-            "npm run build",
-            "npm run e2e"
-          ],
-          "shouldRunCommands": false
-        },
-        {
-          "name": "worker",
-          "commands": ["npm-run-all --parallel redis tsc-watch-start worker"]
-        }
-      ]
-    }
-  ]
+    ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
@@ -9,23 +10,27 @@ import restoreTerminals from "./restoreTerminals";
 
 //do NOT make async and await the async functions in this func, or the command just doesn't work
 export async function activate(context: vscode.ExtensionContext) {
-  console.log("restore-terminals is now active!");
+    console.log("restore-terminals is now active!");
 
-  const config = await getConfiguration(); //mast be done here so json config works for runOnStartup
+    const config = await getConfiguration(); //mast be done here so json config works for runOnStartup
 
-  let disposable = vscode.commands.registerCommand(
-    "restore-terminals.restoreTerminals",
-    async () => {
-      restoreTerminals(await getConfiguration()); //get fresh config here
+    let disposable = vscode.commands.registerCommand(
+        "restore-terminals.restoreTerminals",
+        async () => {
+            const args = await vscode.window.showInputBox({ prompt: 'Enter which terminals to restore' });
+            if (args)
+                restoreTerminals(await getConfiguration(), args); //get fresh config here
+            else
+                restoreTerminals(await getConfiguration()); //get fresh config here
+        }
+    );
+
+    context.subscriptions.push(disposable);
+
+    if (config.runOnStartup) {
+        restoreTerminals(config); //run on startup
     }
-  );
-
-  context.subscriptions.push(disposable);
-
-  if (config.runOnStartup) {
-    restoreTerminals(config); //run on startup
-  }
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,25 +1,27 @@
+/* eslint-disable prettier/prettier */
 import type { TerminalOptions } from "vscode";
 
 export interface TerminalConfig {
-  commands?: string[];
-  name?: string;
-  shouldRunCommands?: boolean; //whether to actually run the commands, or just paste them in
+    commands?: string[];
+    name?: string;
+    shouldRunCommands?: boolean; //whether to actually run the commands, or just paste them in
 }
 
 export interface TerminalWindow {
-  splitTerminals?: TerminalConfig[];
+    name?: string;
+    splitTerminals?: TerminalConfig[];
 }
 
 export interface Configuration {
-  keepExistingTerminalsOpen?: boolean;
-  artificialDelayMilliseconds?: number;
-  terminalWindows?: TerminalWindow[];
-  runOnStartup?: boolean;
+    keepExistingTerminalsOpen?: boolean;
+    artificialDelayMilliseconds?: number;
+    terminalWindows?: TerminalWindow[];
+    runOnStartup?: boolean;
 }
 
 export interface JsonConfiguration {
-  keepExistingTerminalsOpen?: boolean;
-  artificialDelayMilliseconds?: number;
-  terminals?: TerminalWindow[]; //uses same type for now
-  runOnStartup?: boolean;
+    keepExistingTerminalsOpen?: boolean;
+    artificialDelayMilliseconds?: number;
+    terminals?: TerminalWindow[]; //uses same type for now
+    runOnStartup?: boolean;
 }

--- a/src/restoreTerminals.ts
+++ b/src/restoreTerminals.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import * as vscode from "vscode";
 import { delay } from "./utils";
 import { Configuration, TerminalConfig, TerminalWindow } from "./model";
@@ -6,122 +7,125 @@ const DEFAULT_ARTIFICAL_DELAY = 300;
 const SPLIT_TERM_CHECK_DELAY = 100;
 const MAX_TERM_CHECK_ATTEMPTS = 500; //this times SPLIT_TERM_CHECK_DELAY is the timeout
 
-export default async function restoreTerminals(configuration: Configuration) {
-  console.log("restoring terminals", configuration);
-  const {
-    keepExistingTerminalsOpen,
-    artificialDelayMilliseconds,
-    terminalWindows,
-  } = configuration;
+export default async function restoreTerminals(configuration: Configuration, terminalWindowName: string | null = null) {
+    console.log("restoring terminals", configuration);
+    const {
+        keepExistingTerminalsOpen,
+        artificialDelayMilliseconds,
+        terminalWindows,
+    } = configuration;
 
-  if (!terminalWindows) {
-    // vscode.window.showInformationMessage("No terminal window configuration provided to restore terminals with.") //this might be annoying
-    return;
-  }
-
-  if (vscode.window.activeTerminal && !keepExistingTerminalsOpen) {
-    vscode.window.terminals.forEach((terminal) => {
-      //i think calling terminal.dispose before creating the new termials causes error because the terminal has disappeard and it fux up. we can do it after, and check that the terminal we are deleting is not in the list of terminals we just created
-      console.log(`Disposing terminal ${terminal.name}`);
-      terminal.dispose();
-    });
-  }
-  await delay(artificialDelayMilliseconds ?? DEFAULT_ARTIFICAL_DELAY); //without delay it starts bugging out
-
-  let commandsToRunInTerms: {
-    commands: string[];
-    shouldRunCommands: boolean;
-    terminal: vscode.Terminal;
-  }[] = [];
-  //create the terminals sequentially so theres no glitches, but run the commands in parallel
-  for (const terminalWindow of terminalWindows) {
-    if (!terminalWindow.splitTerminals) {
-      // vscode.window.showInformationMessage("No split terminal configuration provided to restore terminals with.") //this might be annoying
-      return;
+    if (!terminalWindows) {
+        // vscode.window.showInformationMessage("No terminal window configuration provided to restore terminals with.") //this might be annoying
+        return;
     }
 
-    let term!: vscode.Terminal;
-    let name = terminalWindow.splitTerminals[0]?.name;
-
-    term = vscode.window.createTerminal({
-      name: name,
-      // cwd: vscode.window.activeTextEditor?.document.uri.fsPath, //i think this happens by default
-    });
-
-    term.show();
-
-    //the first terminal split is already created from when we called createTerminal
-    if (terminalWindow.splitTerminals.length > 0) {
-      const { commands, shouldRunCommands } = terminalWindow.splitTerminals[0];
-      commands &&
-        commandsToRunInTerms.push({
-          commands,
-          shouldRunCommands: shouldRunCommands ?? true,
-          terminal: term,
+    if (vscode.window.activeTerminal && !keepExistingTerminalsOpen) {
+        vscode.window.terminals.forEach((terminal) => {
+            //i think calling terminal.dispose before creating the new termials causes error because the terminal has disappeard and it fux up. we can do it after, and check that the terminal we are deleting is not in the list of terminals we just created
+            console.log(`Disposing terminal ${terminal.name}`);
+            terminal.dispose();
         });
+    }
+    await delay(artificialDelayMilliseconds ?? DEFAULT_ARTIFICAL_DELAY); //without delay it starts bugging out
+
+    let commandsToRunInTerms: {
+        commands: string[];
+        shouldRunCommands: boolean;
+        terminal: vscode.Terminal;
+    }[] = [];
+    //create the terminals sequentially so theres no glitches, but run the commands in parallel
+    for (const terminalWindow of terminalWindows) {
+        if (terminalWindowName != null && terminalWindow.name != terminalWindowName) {
+            continue;
+        }
+        if (!terminalWindow.splitTerminals) {
+            // vscode.window.showInformationMessage("No split terminal configuration provided to restore terminals with.") //this might be annoying
+            return;
+        }
+
+        let term!: vscode.Terminal;
+        let name = terminalWindow.splitTerminals[0]?.name;
+
+        term = vscode.window.createTerminal({
+            name: name,
+            // cwd: vscode.window.activeTextEditor?.document.uri.fsPath, //i think this happens by default
+        });
+
+        term.show();
+
+        //the first terminal split is already created from when we called createTerminal
+        if (terminalWindow.splitTerminals.length > 0) {
+            const { commands, shouldRunCommands } = terminalWindow.splitTerminals[0];
+            commands &&
+                commandsToRunInTerms.push({
+                    commands,
+                    shouldRunCommands: shouldRunCommands ?? true,
+                    terminal: term,
+                });
+        }
+        await delay(artificialDelayMilliseconds ?? DEFAULT_ARTIFICAL_DELAY);
+
+        for (let i = 1; i < terminalWindow.splitTerminals.length; i++) {
+            const splitTerminal = terminalWindow.splitTerminals[i];
+            const createdSplitTerm = await createNewSplitTerminal(splitTerminal.name);
+
+            const { commands, shouldRunCommands } = splitTerminal;
+            commands &&
+                commandsToRunInTerms.push({
+                    commands,
+                    shouldRunCommands: shouldRunCommands ?? true,
+                    terminal: createdSplitTerm,
+                });
+            await delay(artificialDelayMilliseconds ?? DEFAULT_ARTIFICAL_DELAY);
+        }
     }
     await delay(artificialDelayMilliseconds ?? DEFAULT_ARTIFICAL_DELAY);
-
-    for (let i = 1; i < terminalWindow.splitTerminals.length; i++) {
-      const splitTerminal = terminalWindow.splitTerminals[i];
-      const createdSplitTerm = await createNewSplitTerminal(splitTerminal.name);
-
-      const { commands, shouldRunCommands } = splitTerminal;
-      commands &&
-        commandsToRunInTerms.push({
-          commands,
-          shouldRunCommands: shouldRunCommands ?? true,
-          terminal: createdSplitTerm,
-        });
-      await delay(artificialDelayMilliseconds ?? DEFAULT_ARTIFICAL_DELAY);
-    }
-  }
-  await delay(artificialDelayMilliseconds ?? DEFAULT_ARTIFICAL_DELAY);
-  //we run the actual commands in parallel
-  commandsToRunInTerms.forEach(async (el) => {
-    await runCommands(el.commands, el.terminal, el.shouldRunCommands);
-  });
+    //we run the actual commands in parallel
+    commandsToRunInTerms.forEach(async (el) => {
+        await runCommands(el.commands, el.terminal, el.shouldRunCommands);
+    });
 }
 
 async function runCommands(
-  commands: string[],
-  terminal: vscode.Terminal,
-  shouldRunCommands: boolean = true
+    commands: string[],
+    terminal: vscode.Terminal,
+    shouldRunCommands: boolean = true
 ) {
-  for (let j = 0; j < commands?.length; j++) {
-    const command = commands[j] + (shouldRunCommands ? "" : ";"); //add semicolon so all commands can run properly after user presses enter
-    terminal.sendText(command, shouldRunCommands);
-  }
+    for (let j = 0; j < commands?.length; j++) {
+        const command = commands[j] + (shouldRunCommands ? "" : ";"); //add semicolon so all commands can run properly after user presses enter
+        terminal.sendText(command, shouldRunCommands);
+    }
 }
 
 async function createNewSplitTerminal(
-  name: string | undefined
+    name: string | undefined
 ): Promise<vscode.Terminal> {
-  return new Promise(async (resolve, reject) => {
-    const numTermsBefore = vscode.window.terminals.length;
-    await vscode.commands.executeCommand("workbench.action.terminal.split");
-    if (name) {
-      await vscode.commands.executeCommand(
-        "workbench.action.terminal.renameWithArg",
-        {
-          name,
+    return new Promise(async (resolve, reject) => {
+        const numTermsBefore = vscode.window.terminals.length;
+        await vscode.commands.executeCommand("workbench.action.terminal.split");
+        if (name) {
+            await vscode.commands.executeCommand(
+                "workbench.action.terminal.renameWithArg",
+                {
+                    name,
+                }
+            );
         }
-      );
-    }
-    let attemptCount = 0;
-    while (true) {
-      const numTermsNow = vscode.window.terminals?.length;
-      if (attemptCount > MAX_TERM_CHECK_ATTEMPTS) {
-        reject();
-        break;
-      }
-      if (numTermsNow > numTermsBefore) {
-        resolve(vscode.window.terminals[numTermsNow - 1]);
-        break; //we know the terminal has now been split
-      } else {
-        await delay(SPLIT_TERM_CHECK_DELAY);
-        attemptCount++;
-      }
-    }
-  });
+        let attemptCount = 0;
+        while (true) {
+            const numTermsNow = vscode.window.terminals?.length;
+            if (attemptCount > MAX_TERM_CHECK_ATTEMPTS) {
+                reject();
+                break;
+            }
+            if (numTermsNow > numTermsBefore) {
+                resolve(vscode.window.terminals[numTermsNow - 1]);
+                break; //we know the terminal has now been split
+            } else {
+                await delay(SPLIT_TERM_CHECK_DELAY);
+                attemptCount++;
+            }
+        }
+    });
 }


### PR DESCRIPTION
Added support for different types of terminal groups with the same command restore terminals user can will be asked to input terminal group name if none is passed all terminal groups are triggered, in a case where user types in a terminal group name one the one will trigger. Maybe this will be usefull for someone, I really needed that function.