### PR TITLE
add option to set window as active

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -8,6 +8,7 @@ export interface TerminalConfig {
 
 export interface TerminalWindow {
   splitTerminals?: TerminalConfig[];
+  setAsActive?: boolean; //whether to keep the display of the terminal window open even if more windows were opened after this one
 }
 
 export interface Configuration {

--- a/src/restoreTerminals.ts
+++ b/src/restoreTerminals.ts
@@ -13,6 +13,7 @@ export default async function restoreTerminals(configuration: Configuration) {
     artificialDelayMilliseconds,
     terminalWindows,
   } = configuration;
+  let activeWindow = null;
 
   if (!terminalWindows) {
     // vscode.window.showInformationMessage("No terminal window configuration provided to restore terminals with.") //this might be annoying
@@ -75,12 +76,23 @@ export default async function restoreTerminals(configuration: Configuration) {
         });
       await delay(artificialDelayMilliseconds ?? DEFAULT_ARTIFICAL_DELAY);
     }
+
+    if(terminalWindow.setAsActive && !activeWindow){
+      activeWindow = term;
+    }
   }
   await delay(artificialDelayMilliseconds ?? DEFAULT_ARTIFICAL_DELAY);
   //we run the actual commands in parallel
   commandsToRunInTerms.forEach(async (el) => {
     await runCommands(el.commands, el.terminal, el.shouldRunCommands);
   });
+
+  //for some reason running a command in the terminal makes it be shown again so this
+  //needs to be ran after all the commands are executed
+  if(activeWindow){
+    activeWindow.show();
+  }
+
 }
 
 async function runCommands(


### PR DESCRIPTION
Just as small QoL feature. In my particular setup I configured one window with 2 splitted terminals and another window with a single terminal.  the first one is supposed to be the main and the second one is just a windows that I dont always use.

Baiscally this configuration: 
```
     "restoreTerminals.terminals": [
        {
            "splitTerminals": [
                {
                    "name": "main-1",
                },
                {
                    "name": "main-2",
                }
            ]
        },
        {
            "splitTerminals": [
                {
                    "name": "optional",
                },
            ]
        }
    ]
```

what I noticed with this setup is that since optional is created after the main window, it is always the one that ends up being displayed after all commands are ran.

One workaround for this is just setting my main terminals after the optionals (but that feels ugly). so I added a new property at window level to have control over that

https://github.com/EthanSK/restore-terminals-vscode/assets/65191874/6be3d0e0-f946-47e4-9230-62a5bb3a54e1

