### PR TITLE
Added the option to give named configuration instead of only a default one

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,11 @@
   "extends": ["plugin:prettier/recommended"],
   "plugins": ["prettier"],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,55 @@ Simply configure your VSCode settings JSON file to look something like this:
   ]
 ```
 
+Or named configurations that you can choose between:
+
+```
+ "restoreTerminals.terminals": {
+    "dev": [
+      {
+        "splitTerminals": [
+          {
+            "name": "server",
+            "commands": ["npm i", "npm run dev"]
+          },
+          {
+            "name": "client",
+            "commands": ["npm run dev:client"]
+          }
+        ]
+      },
+      {
+        "splitTerminals": [
+          {
+            "name": "worker",
+            "commands": ["npm-run-all --parallel redis tsc-watch-start worker"]
+          }
+        ]
+      }
+    ],
+    "test": [
+      {
+        "splitTerminals": [
+          {
+            "name": "test",
+            "commands": ["jest --watch"],
+            "shouldRunCommands": false
+          }
+        ],
+      },
+      {
+        "splitTerminals": [
+          {
+            "name": "build & e2e",
+            "commands": ["npm run eslint", "npm run build", "npm run e2e"],
+            "shouldRunCommands": false
+          }
+        ],
+      }
+    ]
+  }
+```
+
 The outer array represents a integrated VSCode terminal window, and the `splitTerminals` array contains the information about how each terminal window should be split up.
 
 You can also use a custom config file under. The file should be at `.vscode/restore-terminals.json` in any workspace you want. A sample config file is [here](https://github.com/EthanSK/restore-terminals-vscode/blob/master/sample-test-project/.vscode/restore-terminals.json). If this config file is present, Restore Terminals will try and load settings from it first, then use `settings.json` as a fallback.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "restore-terminals",
-  "version": "1.1.6",
+  "version": "1.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "restore-terminals",
-      "version": "1.1.6",
+      "version": "1.1.8",
       "dependencies": {
         "text-encoding": "^0.7.0"
       },

--- a/package.json
+++ b/package.json
@@ -49,40 +49,91 @@
           "description": "If you find restore terminals glitching out, or running some commands in the wrong window, you might want to try increasing this number to further delay the processing of actions. If you find it taking too long to open the terminal windows, you can try reducing this number, be be cautious as if it's too fast it will bug out."
         },
         "restoreTerminals.terminals": {
-          "type": "array",
-          "items": {
-            "properties": {
-              "splitTerminals": {
+          "type": [
+            "array",
+            "object"
+          ],
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
                 "type": "array",
                 "items": {
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "The name to give the terminal window"
-                    },
-                    "icon": {
-                      "type": "string",
-                      "description": "The icon to give the terminal window"
-                    },
-                    "commands": {
+                    "splitTerminals": {
                       "type": "array",
-                      "description": "The shell commands to execute when this terminal opens.",
                       "items": {
                         "properties": {
-                          "type": "string",
-                          "description": "A shell command to run."
-                        }
+                          "name": {
+                            "type": "string",
+                            "description": "The name to give the terminal window"
+                          },
+                          "icon": {
+                            "type": "string",
+                            "description": "The icon to give the terminal window"
+                          },
+                          "commands": {
+                            "type": "array",
+                            "description": "The shell commands to execute when this terminal opens.",
+                            "items": {
+                              "properties": {
+                                "type": "string",
+                                "description": "A shell command to run."
+                              }
+                            }
+                          },
+                          "shouldRunCommands": {
+                            "type": "boolean",
+                            "description": "Whether to actually run the commands in the terminal, or just paste them there."
+                          }
+                        },
+                        "additionalProperties": false
                       }
-                    },
-                    "shouldRunCommands": {
-                      "type": "boolean",
-                      "description": "Whether to actually run the commands in the terminal, or just paste them there."
                     }
-                  }
+                  },
+                  "additionalProperties": false
                 }
               }
+            },
+            {
+              "type": "array",
+              "items": {
+                "properties": {
+                  "splitTerminals": {
+                    "type": "array",
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "The name to give the terminal window"
+                        },
+                        "icon": {
+                          "type": "string",
+                          "description": "The icon to give the terminal window"
+                        },
+                        "commands": {
+                          "type": "array",
+                          "description": "The shell commands to execute when this terminal opens.",
+                          "items": {
+                            "properties": {
+                              "type": "string",
+                              "description": "A shell command to run."
+                            }
+                          }
+                        },
+                        "shouldRunCommands": {
+                          "type": "boolean",
+                          "description": "Whether to actually run the commands in the terminal, or just paste them there."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
             }
-          }
+          ]
         }
       }
     }

--- a/src/model.ts
+++ b/src/model.ts
@@ -13,7 +13,7 @@ export interface TerminalWindow {
 export interface Configuration {
   keepExistingTerminalsOpen?: boolean;
   artificialDelayMilliseconds?: number;
-  terminalWindows?: TerminalWindow[];
+  terminalWindows?: TerminalWindow[] | Map<string, TerminalWindow[]>;
   runOnStartup?: boolean;
 }
 

--- a/src/restoreTerminals.ts
+++ b/src/restoreTerminals.ts
@@ -8,7 +8,7 @@ const MAX_TERM_CHECK_ATTEMPTS = 500; //this times SPLIT_TERM_CHECK_DELAY is the 
 
 export default async function restoreTerminals(configuration: Configuration) {
   console.log("restoring terminals", configuration);
-  const {
+  let {
     keepExistingTerminalsOpen,
     artificialDelayMilliseconds,
     terminalWindows,
@@ -16,6 +16,35 @@ export default async function restoreTerminals(configuration: Configuration) {
 
   if (!terminalWindows) {
     // vscode.window.showInformationMessage("No terminal window configuration provided to restore terminals with.") //this might be annoying
+    return;
+  }
+
+  if (!(terminalWindows instanceof Array) && terminalWindows !== null) {
+    terminalWindows = new Map(Object.entries(terminalWindows));
+    if (!terminalWindows.size) {
+      vscode.window.showInformationMessage(
+        "Empty terminal window configuration provided to restore terminals with."
+      ); //this might be annoying
+      return;
+    }
+
+    if (terminalWindows.size > 1) {
+      const picked = await vscode.window.showQuickPick(
+        Array.from(terminalWindows.keys())
+      );
+      if (!picked) {
+        return;
+      }
+      terminalWindows = terminalWindows.get(picked) ?? [];
+    } else {
+      terminalWindows = Array.from(terminalWindows.values())[0];
+    }
+  }
+
+  if (!terminalWindows.length) {
+    vscode.window.showInformationMessage(
+      "Empty terminal window configuration provided to restore terminals with."
+    ); //this might be annoying
     return;
   }
 


### PR DESCRIPTION
Like shown in the readme the configuration "restoreTerminals.terminals" now also accepts an object where the key is the name of the configuration and the value is terminals array,
When having more then one configuration it prompts the user to choose what configuration they want to run:
![image](https://github.com/EthanSK/restore-terminals-vscode/assets/67338707/7140b830-b35f-4954-b550-099d8d7de237)
If only one configuration is given it will run it as default the same as giving the terminals array,
The extension is still working when given only the terminals array.